### PR TITLE
Fix for 1.10

### DIFF
--- a/SnapshotTesting.podspec
+++ b/SnapshotTesting.podspec
@@ -1,0 +1,38 @@
+Pod::Spec.new do |s|
+  s.name = "SnapshotTesting"
+  s.version = "1.10.0"
+  s.summary = "Tests that save and assert against reference data"
+
+  s.description = <<-DESC
+  Automatically record app data into test assertions. Snapshot tests capture
+  the entirety of a data structure and cover far more surface area than a
+  typical unit test.
+  DESC
+
+  s.homepage = "https://github.com/pointfreeco/swift-snapshot-testing"
+
+  s.license = "MIT"
+
+  s.authors = {
+    "Stephen Celis" => "stephen@stephencelis.com",
+    "Brandon Williams" => "mbw234@gmail.com"
+  }
+  s.social_media_url = "https://twitter.com/pointfreeco"
+
+  s.source = {
+    :git => "https://github.com/pointfreeco/swift-snapshot-testing.git",
+    :tag => s.version
+  }
+
+  s.swift_versions = "5.0", "5.1.2", "5.2"
+
+  s.ios.deployment_target = "11.0"
+  s.osx.deployment_target = "10.10"
+  s.tvos.deployment_target = "11.0"
+  s.watchos.deployment_target = "7.4"
+
+  s.frameworks = "XCTest"
+  s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
+
+  s.source_files  = "Sources", "Sources/**/*.swift"
+end

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -173,7 +173,7 @@ public func verifySnapshot<Value, Format>(
   )
   -> String? {
 
-      // This has been commented out because it breaks working with Nimble
+      // This has been commented out because it breaks working with Quick
 //    CleanCounterBetweenTestCases.registerIfNeeded()
     let recording = recording || isRecording
 

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -173,7 +173,8 @@ public func verifySnapshot<Value, Format>(
   )
   -> String? {
 
-    CleanCounterBetweenTestCases.registerIfNeeded()
+      // This has been commented out because it breaks working with Nimble
+//    CleanCounterBetweenTestCases.registerIfNeeded()
     let recording = recording || isRecording
 
     do {


### PR DESCRIPTION
- Adds back the pod file with the updated verison number (1.10)
- Removes `CleanCounterBetweenTestCases` as it breaks automatic naming with Quick
  - Issue noted with the main repo here: https://github.com/pointfreeco/swift-snapshot-testing/issues/691