### PR TITLE
Make more flexible for Quick

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Delightful Swift snapshot testing.
 ![An example of a snapshot failure in Xcode.](.github/snapshot-test-1.png)
 -->
 
+## Updates in this Fork
+- Added back Podfile
+- Added the ability to stop the automatic naming reset on each test case execution (did not work with Quick)
+- Exposed `CleanCounterBetweenTestCases.resetAutomaticNaming`
+
 ## Usage
 
 Once [installed](#installation), _no additional configuration is required_. You can import the `SnapshotTesting` module and call the `assertSnapshot` function.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Delightful Swift snapshot testing.
 
 ## Updates in this Fork
 - Added back Podfile
-- Added the ability to stop the automatic naming reset on each test case execution (did not work with Quick)
-- Exposed `CleanCounterBetweenTestCases.resetAutomaticNaming`
+- Adds toggle for turning off automatic naming when XCTestCases finish `CleanCounterBetweenTestCases.cleanBetweenEachTestCase`
+- Adds func that users can call directly to reset automatic test case naming `CleanCounterBetweenTestCases.resetAutomaticNaming`
 
 ## Usage
 

--- a/SnapshotTesting.podspec
+++ b/SnapshotTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "SnapshotTesting"
-  s.version = "1.10.0"
+  s.version = "1.10.1"
   s.summary = "Tests that save and assert against reference data"
 
   s.description = <<-DESC

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -172,9 +172,7 @@ public func verifySnapshot<Value, Format>(
   line: UInt = #line
   )
   -> String? {
-
-      // This has been commented out because it breaks working with Quick
-//    CleanCounterBetweenTestCases.registerIfNeeded()
+    CleanCounterBetweenTestCases.registerIfNeeded()
     let recording = recording || isRecording
 
     do {
@@ -343,22 +341,29 @@ func sanitizePathComponent(_ string: String) -> String {
 }
 
 // We need to clean counter between tests executions in order to support test-iterations.
-private class CleanCounterBetweenTestCases: NSObject, XCTestObservation {
+public class CleanCounterBetweenTestCases: NSObject, XCTestObservation {
     private static var registered = false
     private static var registerQueue = DispatchQueue(label: "co.pointfree.SnapshotTesting.testObserver")
+    public static var cleanBetweenEachTestCase = true
 
     static func registerIfNeeded() {
-      registerQueue.sync {
-        if !registered {
-          registered = true
-          XCTestObservationCenter.shared.addTestObserver(CleanCounterBetweenTestCases())
+        if cleanBetweenEachTestCase {
+            registerQueue.sync {
+                if !registered {
+                    registered = true
+                    XCTestObservationCenter.shared.addTestObserver(CleanCounterBetweenTestCases())
+                }
+            }
         }
-      }
     }
 
-    func testCaseDidFinish(_ testCase: XCTestCase) {
-      counterQueue.sync {
-        counterMap = [:]
-      }
+    public func testCaseDidFinish(_ testCase: XCTestCase) {
+        Self.resetAutomaticNaming()
+    }
+
+    public static func resetAutomaticNaming() {
+        counterQueue.sync {
+          counterMap = [:]
+        }
     }
 }


### PR DESCRIPTION
- Updated README to show what has changed in this fork
- Adds toggle for turning off automatic naming when XCTestCases finish `CleanCounterBetweenTestCases.cleanBetweenEachTestCase`
- Adds func that users can call directly to reset automatic test case naming `CleanCounterBetweenTestCases.resetAutomaticNaming`